### PR TITLE
Fix/Export Board feature ios

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,3 +100,13 @@ B) On Xcode open AAC Cboard.xcworkspace
     Under AAC Cboard Target > info > URL TYPES > 
     add a new one with our APP bundle identifier and set the 'fbXXXXXXXXXXXXX' for the URL SCHEME field.
 <img width="888" alt="configure_FB_login" src="https://github.com/cboard-org/ccboard/assets/21298844/d306ba8a-d903-4ef2-b6d5-80f221338572">
+
+7. In order to allow users to open files created by the Export feature:
+  Edit the plist file 'AAC Cboard-Info.plist' under platforms/ios/AAC Cboard/ 
+ adding this keys and values
+ ```
+    <key>LSSupportsOpeningDocumentsInPlace</key>
+ 	<true/>
+	<key>UIFileSharingEnabled</key>
+	<true/>
+```

--- a/config.xml
+++ b/config.xml
@@ -88,6 +88,9 @@
         <!-- iTunes Marketing Image -->
         <icon src="public/images/artwork/1024.png" width="1024" height="1024" />
         <preference name="KeyboardResize" value="false" />
+        <preference name="scheme" value="app" />
+        <preference name="hostname" value="localhost" />
+        <preference name="iosPersistentFileLocation" value="Compatibility" />
     </platform>
     <platform name="electron">
         <icon src="\www\images\artwork\logo_1x.png" target="app" />


### PR DESCRIPTION
Add necessary changes to allow our Cordova IOS app to use the Export Boards feature. close #51 