### PR TITLE
Update iOS deployment target and plugin versions

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -56,7 +56,7 @@
         </edit-config>
     </platform>
     <platform name="ios">
-        <preference name="deployment-target" value="12.0" />
+        <preference name="deployment-target" value="13.0" />
         <allow-intent href="itms:*" />
         <allow-intent href="itms-apps:*" />
         <!-- iOS 8.0+ -->

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "cordova-browser": "^7.0.0",
-    "cordova-plugin-fbsdk": "4.1.1",
+    "cordova-plugin-fbsdk": "4.0.4",
     "cordova-plugin-ionic-keyboard": "2.2.0",
     "electron-devtools-installer": "^3.2.0",
     "properties-parser": "0.3.1"
@@ -136,7 +136,7 @@
         "FACEBOOK_HYBRID_APP_EVENTS": "false",
         "FACEBOOK_ADVERTISER_ID_COLLECTION": "true",
         "FACEBOOK_ANDROID_SDK_VERSION": "17.0.0",
-        "FACEBOOK_IOS_SDK_VERSION": "17.0.0",
+        "FACEBOOK_IOS_SDK_VERSION": "16.0.1",
         "FACEBOOK_BROWSER_SDK_VERSION": "v19.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "cordova-android": "^13.0.0",
     "cordova-clipboard": "^1.3.0",
     "cordova-electron": "^3.1.0",
-    "cordova-ios": "^6.3.0",
+    "cordova-ios": "^7.1.1",
     "cordova-plugin-android-permissions": "^1.1.5",
     "cordova-plugin-androidx": "^3.0.0",
     "cordova-plugin-androidx-adapter": "^1.1.3",
@@ -53,7 +53,9 @@
       },
       "cordova-plugin-statusbar": {},
       "cordova-plugin-fullscreen": {},
-      "cordova-plugin-media": {},
+      "cordova-plugin-media": {
+        "KEEP_AVAUDIOSESSION_ALWAYS_ACTIVE": "NO"
+      },
       "git+https://github.com/cboard-org/cboard-speech-tts.git": {},
       "cordova-clipboard": {},
       "cordova-plugin-cboard-speech-tts": {},
@@ -114,9 +116,14 @@
         "GOOGLE_ANALYTICS_DEFAULT_ALLOW_AD_STORAGE": "true",
         "GOOGLE_ANALYTICS_DEFAULT_ALLOW_AD_USER_DATA": "true",
         "GOOGLE_ANALYTICS_DEFAULT_ALLOW_AD_PERSONALIZATION_SIGNALS": "true",
-        "FIREBASE_MESSAGING_IMMEDIATE_PAYLOAD_DELIVERY": "false"
+        "FIREBASE_MESSAGING_IMMEDIATE_PAYLOAD_DELIVERY": "false",
+        "IOS_USE_PRECOMPILED_FIRESTORE_POD": "false",
+        "IOS_FCM_ENABLED": "true",
+        "IOS_FIREBASE_SDK_VERSION": "11.2.0",
+        "IOS_FIREBASE_IN_APP_MESSAGING_VERSION": "11.2.0-beta",
+        "IOS_GOOGLE_SIGIN_VERSION": "7.0.0",
+        "IOS_GOOGLE_TAG_MANAGER_VERSION": "8.0.0"
       },
-      "cordova-plugin-ionic-keyboard": {},
       "cordova-plugin-saf-mediastore": {},
       "cordova-plugin-purchase": {},
       "cordova-plugin-fbsdk": {

--- a/package.json
+++ b/package.json
@@ -124,6 +124,7 @@
         "IOS_GOOGLE_SIGIN_VERSION": "7.0.0",
         "IOS_GOOGLE_TAG_MANAGER_VERSION": "8.0.0"
       },
+      "cordova-plugin-ionic-keyboard": {},
       "cordova-plugin-saf-mediastore": {},
       "cordova-plugin-purchase": {},
       "cordova-plugin-fbsdk": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "cordova-plugin-default-browser": "^1.0.0",
     "cordova-plugin-file": "^8.0.1",
     "cordova-plugin-file-opener2": "^2.2.1",
-    "cordova-plugin-firebasex": "18.0.0",
+    "cordova-plugin-firebasex": "18.0.7",
     "cordova-plugin-fullscreen": "^1.3.0",
     "cordova-plugin-iosrtc": "^8.0.4",
     "cordova-plugin-market": "github:xmartlabs/cordova-plugin-market",


### PR DESCRIPTION
Adjust the iOS deployment target to 13.0 and update the versions of `cordova-plugin-firebasex`.
Downgrade the `cordova-plugin-fbsdk` to maintain compatibility with our API.